### PR TITLE
Diagnostiquer le problème signalé

### DIFF
--- a/public/js/communications.js
+++ b/public/js/communications.js
@@ -10,6 +10,8 @@
       const data = await res.json();
       const box = document.querySelector(`.messages[data-peer="${peer}"]`);
       if (!box) return;
+      const wasNearBottom = isNearBottom(box);
+      const prevScrollTop = box.scrollTop;
       box.innerHTML = '';
       const msgs = (data.messages || []);
       for (let i = 0; i < msgs.length; i++) {
@@ -24,12 +26,21 @@
         }
         box.appendChild(div);
       }
-      box.scrollTop = box.scrollHeight;
+      if (wasNearBottom) {
+        box.scrollTop = box.scrollHeight;
+      } else {
+        box.scrollTop = prevScrollTop;
+      }
     } catch {}
   }
 
   function escapeHtml(s){
     return (s||'').replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#39;'}[c]));
+  }
+
+  function isNearBottom(el, threshold = 80) {
+    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+    return distanceFromBottom <= threshold;
   }
 
   async function sendMessage(peer, content, csrfToken) {


### PR DESCRIPTION
Prevent chat auto-scroll from forcing users to the bottom when reading older messages.

---
<a href="https://cursor.com/background-agent?bcId=bc-eb03be59-c98d-4cd0-8baf-1f7c3db5ce9d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-eb03be59-c98d-4cd0-8baf-1f7c3db5ce9d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

